### PR TITLE
feat: start tracking release metrics for ipfs/kubo

### DIFF
--- a/base/release-metrics-values.yaml
+++ b/base/release-metrics-values.yaml
@@ -22,6 +22,7 @@ spec:
       repos:
       - filecoin-project/lotus
       - filecoin-project/helm-charts
+      - ipfs/kubo
     dockerhub:
       interval : 10m
       listenPort: 9888
@@ -30,12 +31,14 @@ spec:
       - filecoin/lotus
       - filecoin/lotus-all-in-one
       - filecoin/lotus-test
+      - ipfs/kubo
     homebrew:
       interval : 10m
       listenPort: 9888
       metricsPath: /metrics
       formulae:
       - filecoin-project/lotus/lotus
+      - ipfs
     snapcraft:
       interval : 10m
       listenPort: 9888


### PR DESCRIPTION
Could we start tracking Kubo release metrics? Later, I'd be very much interested in doing a similar thing for other IP Stewards managed projects but I think Kubo is a good place to start.

Is the data going to be available in Grafana after these changes are applied or are there any other actions required?